### PR TITLE
Add missing link to binlist/data

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ License](http://www.opensource.org/licenses/mit-license.php).
 [GitHub pages]: https://pages.github.com
 [fences]:https://help.github.com/articles/github-flavored-markdown#syntax-highlighting
 [DocumentUp]: http://documentup.com
+[binlist-data]: https://github.com/binlist/data


### PR DESCRIPTION
Unless I'm misunderstanding this repo, this URL was expected https://github.com/binlist/data